### PR TITLE
Cache configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,23 @@ yarn add apollo-mocked-provider
 import {
   createApolloErrorProvider,
   createApolloMockedProvider,
-  createApolloLoadingProvider
-} from "apollo-mocked-provider";
-import { typeDefs } from "./typeDefs";
-import { InMemoryCache } from "apollo-boost";
+  createApolloLoadingProvider,
+} from 'apollo-mocked-provider';
+import { typeDefs } from './typeDefs';
 
-const cache = new InMemoryCache();
-
-export const ApolloMockedProvider = createApolloMockedProvider(typeDefs, cache);
-export const ApolloErrorProvider = createApolloErrorProvider(cache);
-export const ApolloLoadingProvider = createApolloLoadingProvider(cache);
+export const ApolloMockedProvider = createApolloMockedProvider(typeDefs);
+export const ApolloErrorProvider = createApolloErrorProvider();
+export const ApolloLoadingProvider = createApolloLoadingProvider();
 ```
 
 You can get the `typeDefs` with this helper file
 
 ```js
 // downloadTypeDefs.js
-const { fetchTypeDefs } = require("apollo-mocked-provider");
+const { fetchTypeDefs } = require('apollo-mocked-provider');
 
 (() => {
-  fetchTypeDefs({ uri: "http://localhost:4000/graphql" });
+  fetchTypeDefs({ uri: 'http://localhost:4000/graphql' });
 })();
 ```
 
@@ -48,18 +45,18 @@ node downloadTypeDefs.js
 ## testing
 
 ```jsx
-import React from "react";
-import { render, cleanup } from "@testing-library/react";
-import { Todos } from "./Todos";
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { Todos } from './Todos';
 import {
   ApolloLoadingProvider,
   ApolloErrorProvider,
-  ApolloMockedProvider
-} from "./test-utils/providers";
+  ApolloMockedProvider,
+} from './test-utils/providers';
 
 afterEach(cleanup);
 
-test("TodoForm", async () => {
+test('TodoForm', async () => {
   const { debug } = render(
     <ApolloMockedProvider>
       <Todos />
@@ -75,19 +72,18 @@ test("TodoForm", async () => {
 Loading:
 
 ```jsx
-
-import React from "react";
-import { render, cleanup } from "@testing-library/react";
-import { Todos } from "./Todos";
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { Todos } from './Todos';
 import {
   ApolloLoadingProvider,
   ApolloErrorProvider,
-  ApolloMockedProvider
-} from "./test-utils/providers";
+  ApolloMockedProvider,
+} from './test-utils/providers';
 
 afterEach(cleanup);
 
-test("TodoForm", async () => {
+test('TodoForm', async () => {
   const { debug } = render(
     <ApolloLoadingProvider>
       <Todos />
@@ -96,59 +92,56 @@ test("TodoForm", async () => {
 
   debug();
 });
-
 ```
 
 Error:
 
 ```jsx
-
-import React from "react";
-import { render, cleanup } from "@testing-library/react";
-import { Todos } from "./Todos";
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { Todos } from './Todos';
 import {
   ApolloLoadingProvider,
   ApolloErrorProvider,
-  ApolloMockedProvider
-} from "./test-utils/providers";
+  ApolloMockedProvider,
+} from './test-utils/providers';
 
 afterEach(cleanup);
 
-test("TodoForm", async () => {
+test('TodoForm', async () => {
   const { debug } = render(
-    <ApolloErrorProvider graphQLErrors={[{ message: "something went wrong" }]}>
+    <ApolloErrorProvider graphQLErrors={[{ message: 'something went wrong' }]}>
       <Todos />
     </ApolloErrorProvider>
   );
 
   debug();
-  await Promise.resolve()
+  await Promise.resolve();
   debug();
 });
-
 ```
 
 Custom mocks:
 
 ```jsx
-import React from "react";
-import { render, cleanup } from "@testing-library/react";
-import { Todos } from "./Todos";
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { Todos } from './Todos';
 import {
   ApolloLoadingProvider,
   ApolloErrorProvider,
-  ApolloMockedProvider
-} from "./test-utils/providers";
+  ApolloMockedProvider,
+} from './test-utils/providers';
 
 afterEach(cleanup);
 
-test("TodoForm", async () => {
+test('TodoForm', async () => {
   const { debug } = render(
     <ApolloMockedProvider
       customResolvers={{
         Query: () => ({
-          todos: () => [{ id: 1, type: "hello from custom mocked data" }]
-        })
+          todos: () => [{ id: 1, type: 'hello from custom mocked data' }],
+        }),
       }}
     >
       <Todos />
@@ -158,5 +151,30 @@ test("TodoForm", async () => {
   debug();
   await Promise.resolve();
   debug();
+});
+```
+
+### Cache
+
+By default, providers will use a new instance of [`InMemoryCache`](https://www.apollographql.com/docs/react/advanced/caching/#inmemorycache), but you can override that at a global or per component level by providing an object that implements `ApolloCache` to the `create*` methods or mocked components respectively.
+
+```jsx
+import { InMemoryCache } from 'apollo-boost';
+
+// global, shared cache
+const globalCache = new InMemoryCache();
+export const ApolloMockedProvider = createApolloMockedProvider(
+  typeDefs,
+  globalCache
+);
+
+test('local cache', async () => {
+  // local, scoped cache
+  const localCache = new InMemoryCache();
+  const { debug } = render(
+    <ApolloMockedProvider cache={localCache}>
+      <Todos />
+    </ApolloMockedProvider>
+  );
 });
 ```

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "typescript": "^3.5.2"
   },
   "dependencies": {
+    "apollo-cache-inmemory": "^1.6.2",
     "apollo-client": "^2.6.2",
     "apollo-link-http": "^1.5.14",
     "apollo-link-schema": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
   "files": [
     "dist"
   ],
+  "jest": {
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup.ts"
+    ]
+  },
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",
@@ -48,10 +53,12 @@
     "trailingComma": "es5"
   },
   "devDependencies": {
+    "@testing-library/react": "^8.0.1",
     "@types/graphql": "^14.2.0",
     "@types/jest": "^24.0.14",
     "@types/react": "^16.8.20",
     "@types/react-dom": "^16.8.4",
+    "apollo-boost": "^0.4.3",
     "husky": "^2.4.1",
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "pretty-quick --staged",
+      "pre-push": "npm test"
     }
   },
   "prettier": {

--- a/src/createApolloErrorProvider.tsx
+++ b/src/createApolloErrorProvider.tsx
@@ -4,12 +4,15 @@ import { ApolloProvider } from 'react-apollo';
 import ApolloClient from 'apollo-client';
 import { GraphQLError } from 'graphql';
 import { ApolloCache } from 'apollo-cache';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 
-export const createApolloErrorProvider = (apolloCache: ApolloCache<any>) => ({
+export const createApolloErrorProvider = (globalCache?: ApolloCache<any>) => ({
   graphQLErrors,
+  cache,
   children,
 }: {
   graphQLErrors: GraphQLError[];
+  cache?: ApolloCache<any>;
   children: React.ReactNode | JSX.Element;
 }) => {
   // This is just a link that swallows all operations and returns the same thing
@@ -27,7 +30,7 @@ export const createApolloErrorProvider = (apolloCache: ApolloCache<any>) => ({
 
   const client = new ApolloClient({
     link,
-    cache: apolloCache,
+    cache: cache || globalCache || new InMemoryCache(),
   });
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>;

--- a/src/createApolloLoadingProvider.tsx
+++ b/src/createApolloLoadingProvider.tsx
@@ -3,11 +3,16 @@ import { ApolloLink, Observable } from 'apollo-link';
 import ApolloClient from 'apollo-client';
 import { ApolloProvider } from 'react-apollo';
 import { ApolloCache } from 'apollo-cache';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 
-export const createApolloLoadingProvider = (apolloCache: ApolloCache<any>) => ({
+export const createApolloLoadingProvider = (
+  globalCache?: ApolloCache<any>
+) => ({
   children,
+  cache,
 }: {
   children: React.ReactChild | JSX.Element;
+  cache?: ApolloCache<any>;
 }) => {
   const link = new ApolloLink(() => {
     return new Observable(() => {});
@@ -15,7 +20,7 @@ export const createApolloLoadingProvider = (apolloCache: ApolloCache<any>) => ({
 
   const client = new ApolloClient({
     link,
-    cache: apolloCache,
+    cache: cache || globalCache || new InMemoryCache(),
   });
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>;

--- a/src/createApolloMockedProvider.tsx
+++ b/src/createApolloMockedProvider.tsx
@@ -8,16 +8,19 @@ import {
 import ApolloClient from 'apollo-client';
 import { SchemaLink } from 'apollo-link-schema';
 import { ApolloCache } from 'apollo-cache';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 
 export const createApolloMockedProvider = (
   typeDefs: ITypeDefinitions,
-  apolloCache: ApolloCache<any>
+  globalCache?: ApolloCache<any>
 ) => ({
   customResolvers = {},
+  cache,
   children,
 }: {
   customResolvers?: any;
   children: React.ReactChild | JSX.Element;
+  cache?: ApolloCache<any>;
 }) => {
   // const mocks = mergeResolvers(globalMocks, props.customResolvers);
 
@@ -30,7 +33,7 @@ export const createApolloMockedProvider = (
 
   const client = new ApolloClient({
     link: new SchemaLink({ schema }),
-    cache: apolloCache,
+    cache: cache || globalCache || new InMemoryCache(),
   });
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>;

--- a/test/createApolloErrorProvider.test.tsx
+++ b/test/createApolloErrorProvider.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createApolloErrorProvider } from '../src';
+import { render, waitForDomChange } from '@testing-library/react';
+import { Todo } from './fixtures/Todo';
+
+test('works with defaults', async () => {
+  const MockedProvider = createApolloErrorProvider();
+  const { getByText } = render(
+    <MockedProvider graphQLErrors={[]}>
+      <Todo />
+    </MockedProvider>
+  );
+
+  await waitForDomChange();
+  expect(getByText('Error!')).toBeTruthy();
+});

--- a/test/createApolloLoadingProvider.test.tsx
+++ b/test/createApolloLoadingProvider.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { createApolloLoadingProvider } from '../src';
+import { render } from '@testing-library/react';
+import { Todo } from './fixtures/Todo';
+
+test('works with defaults', async () => {
+  const MockedProvider = createApolloLoadingProvider();
+  const { getByText } = render(
+    <MockedProvider>
+      <Todo />
+    </MockedProvider>
+  );
+
+  expect(getByText('Loading...')).toBeTruthy();
+});

--- a/test/createApolloMockedProvider.test.tsx
+++ b/test/createApolloMockedProvider.test.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { createApolloMockedProvider } from '../src';
+import { readFileSync } from 'fs';
+import { render, waitForDomChange, wait } from '@testing-library/react';
+import { GET_TODOS_QUERY, Todo } from './fixtures/Todo';
+import path from 'path';
+import { InMemoryCache } from 'apollo-boost';
+
+const typeDefs = readFileSync(
+  path.join(__dirname, 'fixtures/simpleSchema.graphql'),
+  'utf8'
+);
+
+test('works with defaults', async () => {
+  const MockedProvider = createApolloMockedProvider(typeDefs);
+  const { getByTestId } = render(
+    <MockedProvider>
+      <Todo />
+    </MockedProvider>
+  );
+
+  await waitForDomChange();
+  const todoList = getByTestId('todolist');
+  expect(todoList).toBeTruthy();
+  expect(todoList.children.length).toBeGreaterThanOrEqual(1);
+});
+
+test('works with custom resolvers', async () => {
+  const MockedProvider = createApolloMockedProvider(typeDefs);
+  const { getByText } = render(
+    <MockedProvider
+      customResolvers={{
+        Query: () => ({
+          todos: () => [
+            {
+              text: 'First Todo',
+            },
+            {
+              text: 'Second Todo',
+            },
+          ],
+        }),
+      }}
+    >
+      <Todo />
+    </MockedProvider>
+  );
+
+  await waitForDomChange();
+
+  expect(getByText('First Todo')).toBeTruthy();
+  expect(getByText('Second Todo')).toBeTruthy();
+});
+
+describe('caching', () => {
+  test('allows users to provide a global cache', async () => {
+    const cache = new InMemoryCache();
+    const FirstMockedProvider = createApolloMockedProvider(typeDefs, cache);
+    cache.writeQuery({
+      query: GET_TODOS_QUERY,
+      data: {
+        todos: [
+          {
+            id: '46e28ed9-1b92-4e1f-9fdf-f1e773dd5448',
+            text: 'First Global Todo',
+            createdTs: 10,
+            __typename: 'Todo',
+          },
+          {
+            id: '5451e580-291c-4a90-bb28-7602bfef64f1',
+            text: 'Second Global Todo',
+            createdTs: -11,
+            __typename: 'Todo',
+          },
+        ],
+      },
+    });
+
+    const { getByText } = render(
+      <FirstMockedProvider customResolvers={{}}>
+        <Todo />
+      </FirstMockedProvider>,
+      {
+        container: document.createElement('div'),
+      }
+    );
+
+    await wait();
+    expect(getByText('First Global Todo')).toBeTruthy();
+    expect(getByText('Second Global Todo')).toBeTruthy();
+
+    const SecondMockedProvider = createApolloMockedProvider(typeDefs, cache);
+    const { getByText: secondGetByText } = render(
+      <SecondMockedProvider>
+        <Todo />
+      </SecondMockedProvider>,
+      {
+        container: document.createElement('div'),
+      }
+    );
+
+    expect(secondGetByText('First Global Todo')).toBeTruthy();
+    expect(secondGetByText('Second Global Todo')).toBeTruthy();
+  });
+
+  test('allows users to provide a local cache', () => {
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: GET_TODOS_QUERY,
+      data: {
+        todos: [
+          {
+            id: '46e28ed9-1b92-4e1f-9fdf-f1e773dd5448',
+            text: 'First Local Todo',
+            createdTs: 10,
+            __typename: 'Todo',
+          },
+          {
+            id: '5451e580-291c-4a90-bb28-7602bfef64f1',
+            text: 'Second Local Todo',
+            createdTs: -11,
+            __typename: 'Todo',
+          },
+        ],
+      },
+    });
+
+    const FirstMockedProvider = createApolloMockedProvider(typeDefs);
+
+    const { getByText } = render(
+      <FirstMockedProvider cache={cache}>
+        <Todo />
+      </FirstMockedProvider>
+    );
+
+    expect(getByText('First Local Todo')).toBeTruthy();
+    expect(getByText('Second Local Todo')).toBeTruthy();
+  });
+
+  test('it does not call custom resolvers for cached values. This a document of behavior, not necessarily desired. We may need to build around in the future.', () => {
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: GET_TODOS_QUERY,
+      data: {
+        todos: [
+          {
+            id: '46e28ed9-1b92-4e1f-9fdf-f1e773dd5448',
+            text: 'First Local Todo',
+            createdTs: 10,
+            __typename: 'Todo',
+          },
+          {
+            id: '5451e580-291c-4a90-bb28-7602bfef64f1',
+            text: 'Second Local Todo',
+            createdTs: -11,
+            __typename: 'Todo',
+          },
+        ],
+      },
+    });
+
+    const FirstMockedProvider = createApolloMockedProvider(typeDefs);
+
+    const { getByText } = render(
+      <FirstMockedProvider
+        customResolvers={{
+          Query: () => {
+            return {
+              todos: () => [
+                {
+                  text: 'First Todo',
+                },
+                {
+                  text: 'Second Todo',
+                },
+              ],
+            };
+          },
+        }}
+        cache={cache}
+      >
+        <Todo />
+      </FirstMockedProvider>
+    );
+
+    expect(getByText('First Local Todo')).toBeTruthy();
+    expect(getByText('Second Local Todo')).toBeTruthy();
+  });
+});

--- a/test/fixtures/Todo.tsx
+++ b/test/fixtures/Todo.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Mutation, Query } from 'react-apollo';
+import { gql } from 'apollo-boost';
+
+export const GET_TODOS_QUERY = gql`
+  query getTodos {
+    todos {
+      id
+      text
+      createdTs
+    }
+  }
+`;
+
+export const ADD_TODO_MUTATION = gql`
+  mutation addTodo($input: AddTodoInput) {
+    addTodo(input: $input) {
+      id
+      createdTs
+    }
+  }
+`;
+
+interface Todo {
+  id: string;
+  text: string;
+  createdTs: number;
+}
+
+interface Data {
+  todos: Array<Todo>;
+}
+
+interface AddTodo {
+  addTodo: Todo;
+}
+
+export const Todo = () => (
+  <Query<Data> query={GET_TODOS_QUERY}>
+    {({ loading, error, data }) => {
+      if (loading) return <p>Loading...</p>;
+      if (error) return <p>Error!</p>;
+      return (
+        <>
+          <ul data-testid="todolist">
+            {data!.todos.map((todo, idx) => (
+              <li key={idx}>{todo.text}</li>
+            ))}
+          </ul>
+          <Mutation<AddTodo> mutation={ADD_TODO_MUTATION}>
+            {(addTodo, { error: mutationError, data: mutationData }) => {
+              return (
+                <div>
+                  {!mutationError && mutationData && mutationData.addTodo && (
+                    <>Successfully added {mutationData.addTodo.text}</>
+                  )}
+                  <button
+                    onClick={() => {
+                      addTodo({ variables: { input: { text: 'hardcoded' } } });
+                    }}
+                  >
+                    Add todo
+                  </button>
+                  {mutationError && <div>{mutationError.message}</div>}
+                </div>
+              );
+            }}
+          </Mutation>
+        </>
+      );
+    }}
+  </Query>
+);

--- a/test/fixtures/simpleSchema.graphql
+++ b/test/fixtures/simpleSchema.graphql
@@ -1,0 +1,21 @@
+type Query {
+  todos: [Todo]!
+  todo(id: ID!): Todo
+}
+
+type Mutation {
+  addTodo(input: AddTodoInput): Todo
+}
+
+input AddTodoInput {
+  text: String!
+}
+
+type Todo {
+  id: ID!
+  text: String!
+  # A unix timestamp
+  # we can consider adding a custom Date scalar if we really want to
+  # to help exercise mocking custom scalars
+  createdTs: Int
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/react/cleanup-after-each';

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,7 +875,7 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/node@*", "@types/node@^12.0.8":
+"@types/node@*", "@types/node@>=6", "@types/node@^12.0.8":
   version "12.0.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
   integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
@@ -1073,6 +1073,14 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@wry/context@^0.4.0":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.4.4.tgz#e50f5fa1d6cfaabf2977d1fda5ae91717f8815f8"
+  integrity sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==
+  dependencies:
+    "@types/node" ">=6"
+    tslib "^1.9.3"
+
 "@wry/equality@^0.1.2":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
@@ -1188,7 +1196,18 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apollo-cache@1.3.2:
+apollo-cache-inmemory@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.2.tgz#bbf2e4e1eacdf82b2d526f5c2f3b37e5acee3c5e"
+  integrity sha512-AyCl3PGFv5Qv1w4N9vlg63GBPHXgMCekZy5mhlS042ji0GW84uTySX+r3F61ZX3+KM1vA4m9hQyctrEGiv5XjQ==
+  dependencies:
+    apollo-cache "^1.3.2"
+    apollo-utilities "^1.3.2"
+    optimism "^0.9.0"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+
+apollo-cache@1.3.2, apollo-cache@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.2.tgz#df4dce56240d6c95c613510d7e409f7214e6d26a"
   integrity sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==
@@ -4477,6 +4496,13 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+optimism@^0.9.0:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.9.5.tgz#b8b5dc9150e97b79ddbf2d2c6c0e44de4d255527"
+  integrity sha512-lNvmuBgONAGrUbj/xpH69FjMOz1d0jvMNoOCKyVynUPzq2jgVlGL4jFYJqrUHzUfBv+jAFSCP61x5UkfbduYJA==
+  dependencies:
+    "@wry/context" "^0.4.0"
 
 optimist@^0.6.1:
   version "0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,6 +613,13 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
+"@babel/runtime@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -799,6 +806,30 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
+
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
+"@testing-library/dom@^5.0.0":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.2.1.tgz#3f2af5229af106c0ccd5078bcb820958310604bc"
+  integrity sha512-K30UE+UKwyI/iTaQsSJXVYBPnPsTLlcNT1QEhHKKqlsehu7SzWTSkCE3xW0qvMPIkPb3/rVisDx7Viez/qmAKA==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    aria-query "3.0.0"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
+"@testing-library/react@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.1.tgz#91c254adf855b13de50020613cb5d3915f9f7875"
+  integrity sha512-N/1pJfhEnNYkGyxuw4xbp03evaS0z/CT8o0QgTfJqGlukAcU15xf9uU1w03NHKZJcU69nOCBAoAkXHtHzYwMbg==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@testing-library/dom" "^5.0.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"
@@ -1196,6 +1227,21 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+apollo-boost@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/apollo-boost/-/apollo-boost-0.4.3.tgz#107bd1dd0d349d8e363174ded69612a4aa823c8a"
+  integrity sha512-XE7hx4aXRnyZ4OGM8I7DjYq9SYLYWrVBoYpEFsv0GBtfIl6tipyks2Yo2/TEWKw7mhGmi1eFB2F3pbhIZbzKuQ==
+  dependencies:
+    apollo-cache "^1.3.2"
+    apollo-cache-inmemory "^1.6.2"
+    apollo-client "^2.6.3"
+    apollo-link "^1.0.6"
+    apollo-link-error "^1.0.3"
+    apollo-link-http "^1.3.1"
+    graphql-tag "^2.4.2"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+
 apollo-cache-inmemory@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.2.tgz#bbf2e4e1eacdf82b2d526f5c2f3b37e5acee3c5e"
@@ -1229,6 +1275,29 @@ apollo-client@^2.6.2:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
+apollo-client@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.3.tgz#9bb2d42fb59f1572e51417f341c5f743798d22db"
+  integrity sha512-DS8pmF5CGiiJ658dG+mDn8pmCMMQIljKJSTeMNHnFuDLV0uAPZoeaAwVFiAmB408Ujqt92oIZ/8yJJAwSIhd4A==
+  dependencies:
+    "@types/zen-observable" "^0.8.0"
+    apollo-cache "1.3.2"
+    apollo-link "^1.0.0"
+    apollo-utilities "1.3.2"
+    symbol-observable "^1.0.2"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+    zen-observable "^0.8.0"
+
+apollo-link-error@^1.0.3:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.11.tgz#7cd363179616fb90da7866cee85cb00ee45d2f3b"
+  integrity sha512-442DNqn3CNRikDaenMMkoDmCRmkoUx/XyUMlRTZBEFdTw3FYPQLsmDO3hzzC4doY5/BHcn9/jdYh9EeLx4HPsA==
+  dependencies:
+    apollo-link "^1.2.12"
+    apollo-link-http-common "^0.2.14"
+    tslib "^1.9.3"
+
 apollo-link-http-common@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz#c688f6baaffdc7b269b2db7ae89dae7c58b5b350"
@@ -1236,6 +1305,24 @@ apollo-link-http-common@^0.2.13:
   dependencies:
     apollo-link "^1.2.11"
     ts-invariant "^0.3.2"
+    tslib "^1.9.3"
+
+apollo-link-http-common@^0.2.14:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz#d3a195c12e00f4e311c417f121181dcc31f7d0c8"
+  integrity sha512-v6mRU1oN6XuX8beVIRB6OpF4q1ULhSnmy7ScnHnuo1qV6GaFmDcbdvXqxIkAV1Q8SQCo2lsv4HeqJOWhFfApOg==
+  dependencies:
+    apollo-link "^1.2.12"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+
+apollo-link-http@^1.3.1:
+  version "1.5.15"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.15.tgz#106ab23bb8997bd55965d05855736d33119652cf"
+  integrity sha512-epZFhCKDjD7+oNTVK3P39pqWGn4LEhShAoA1Q9e2tDrBjItNfviiE33RmcLcCURDYyW5JA6SMgdODNI4Is8tvQ==
+  dependencies:
+    apollo-link "^1.2.12"
+    apollo-link-http-common "^0.2.14"
     tslib "^1.9.3"
 
 apollo-link-http@^1.5.14:
@@ -1264,6 +1351,16 @@ apollo-link@^1.0.0, apollo-link@^1.2.11, apollo-link@^1.2.3:
     ts-invariant "^0.3.2"
     tslib "^1.9.3"
     zen-observable-ts "^0.8.18"
+
+apollo-link@^1.0.6, apollo-link@^1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.12.tgz#014b514fba95f1945c38ad4c216f31bcfee68429"
+  integrity sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==
+  dependencies:
+    apollo-utilities "^1.3.0"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+    zen-observable-ts "^0.8.19"
 
 apollo-utilities@1.3.2, apollo-utilities@^1.0.1, apollo-utilities@^1.2.1, apollo-utilities@^1.3.0, apollo-utilities@^1.3.2:
   version "1.3.2"
@@ -1294,6 +1391,14 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
+  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -1375,6 +1480,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -1897,7 +2007,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.19.0, commander@~2.20.0:
+commander@^2.11.0, commander@^2.19.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -2790,6 +2900,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graphql-tag@^2.4.2:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
+  integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
 graphql-tools@^4.0.4:
   version "4.0.4"
@@ -6280,6 +6395,11 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
+wait-for-expect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
+  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
+
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -6511,6 +6631,14 @@ zen-observable-ts@^0.8.18:
   version "0.8.18"
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz#ade44b1060cc4a800627856ec10b9c67f5f639c8"
   integrity sha512-q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==
+  dependencies:
+    tslib "^1.9.3"
+    zen-observable "^0.8.0"
+
+zen-observable-ts@^0.8.19:
+  version "0.8.19"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz#c094cd20e83ddb02a11144a6e2a89706946b5694"
+  integrity sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==
   dependencies:
     tslib "^1.9.3"
     zen-observable "^0.8.0"


### PR DESCRIPTION
This attempts to resolve #1 (an issue that I myself had encountered) by defaulting each created component to using its own `InMemoryCache`, but also allowing configuration at a global and local level.

A few notes:

- I went ahead and added some tests, with a small example component. Please let me know if there's a different direction you want to head in with testing
  - this means a few extra `apollo-*` dependencies in dev but that seems acceptable
- There's a big diff from `prettier` due to the [single quote](https://github.com/benawad/apollo-mocked-provider/blob/master/package.json#L46-L47) setting. I'm not sure why the original source was single double quoted. If double quotes are preferred, we can change the setting in `package.json` and I can re-run prettier on this PR