### PR TITLE
feature: support using different ApolloProviders

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ Then run that file
 node downloadTypeDefs.js
 ```
 
+### Using apollo-hooks-provider
+
+If you would like to use [react-apollo-hooks](https://github.com/trojanowski/react-apollo-hooks) you can pass a custom
+provider to the `createApollo*` functions:
+
+```jsx
+import { ApolloProvider } from 'react-apollo-hooks';
+
+export const ApolloMockedProvider = createApolloMockedProvider(
+  typeDefs,
+  undefined,
+  ApolloProvider
+);
+export const ApolloErrorProvider = createApolloErrorProvider(
+  undefined,
+  ApolloProvider
+);
+export const ApolloLoadingProvider = createApolloLoadingProvider(
+  undefined,
+  ApolloProvider
+);
+```
+
 ## testing
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -42,29 +42,6 @@ Then run that file
 node downloadTypeDefs.js
 ```
 
-### Using apollo-hooks-provider
-
-If you would like to use [react-apollo-hooks](https://github.com/trojanowski/react-apollo-hooks) you can pass a custom
-provider to the `createApollo*` functions:
-
-```jsx
-import { ApolloProvider } from 'react-apollo-hooks';
-
-export const ApolloMockedProvider = createApolloMockedProvider(
-  typeDefs,
-  undefined,
-  ApolloProvider
-);
-export const ApolloErrorProvider = createApolloErrorProvider(
-  undefined,
-  ApolloProvider
-);
-export const ApolloLoadingProvider = createApolloLoadingProvider(
-  undefined,
-  ApolloProvider
-);
-```
-
 ## testing
 
 ```jsx
@@ -199,5 +176,24 @@ test('local cache', async () => {
       <Todos />
     </ApolloMockedProvider>
   );
+});
+```
+
+### Using apollo-hooks-provider
+
+If you would like to use [react-apollo-hooks](https://github.com/trojanowski/react-apollo-hooks) you can pass a custom
+provider to the `createApollo*` functions:
+
+```jsx
+import { ApolloProvider } from 'react-apollo-hooks';
+
+export const ApolloMockedProvider = createApolloMockedProvider(typeDefs, {
+  provider: ApolloProvider,
+});
+export const ApolloErrorProvider = createApolloErrorProvider({
+  provider: ApolloProvider,
+});
+export const ApolloLoadingProvider = createApolloLoadingProvider({
+  provider: ApolloProvider,
 });
 ```

--- a/src/ApolloMockedProviderOptions.ts
+++ b/src/ApolloMockedProviderOptions.ts
@@ -1,0 +1,7 @@
+import { ApolloCache } from 'apollo-cache';
+import { ApolloProviderProps } from 'react-apollo';
+
+export interface ApolloMockedProviderOptions {
+  cache?: ApolloCache<any>;
+  provider?: React.ComponentType<ApolloProviderProps<any>>;
+}

--- a/src/createApolloErrorProvider.tsx
+++ b/src/createApolloErrorProvider.tsx
@@ -3,13 +3,14 @@ import { ApolloLink, Observable } from 'apollo-link';
 import ApolloClient from 'apollo-client';
 import { GraphQLError } from 'graphql';
 import { ApolloCache } from 'apollo-cache';
-import { ApolloProviderProps, ApolloProvider } from 'react-apollo';
+import { ApolloProvider } from 'react-apollo';
 import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloMockedProviderOptions } from './ApolloMockedProviderOptions';
 
-export const createApolloErrorProvider = (
-  globalCache?: ApolloCache<any>,
-  provider?: React.ComponentType<ApolloProviderProps<any>>
-) => ({
+export const createApolloErrorProvider = ({
+  cache: globalCache,
+  provider,
+}: ApolloMockedProviderOptions = {}) => ({
   graphQLErrors,
   cache,
   children,

--- a/src/createApolloErrorProvider.tsx
+++ b/src/createApolloErrorProvider.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { ApolloLink, Observable } from 'apollo-link';
-import { ApolloProvider } from 'react-apollo';
 import ApolloClient from 'apollo-client';
 import { GraphQLError } from 'graphql';
 import { ApolloCache } from 'apollo-cache';
+import { ApolloProviderProps, ApolloProvider } from 'react-apollo';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 
-export const createApolloErrorProvider = (globalCache?: ApolloCache<any>) => ({
+export const createApolloErrorProvider = (
+  globalCache?: ApolloCache<any>,
+  provider?: React.ComponentType<ApolloProviderProps<any>>
+) => ({
   graphQLErrors,
   cache,
   children,
@@ -33,5 +36,6 @@ export const createApolloErrorProvider = (globalCache?: ApolloCache<any>) => ({
     cache: cache || globalCache || new InMemoryCache(),
   });
 
-  return <ApolloProvider client={client}>{children}</ApolloProvider>;
+  const Provider = provider ? provider : ApolloProvider;
+  return <Provider client={client}>{children}</Provider>;
 };

--- a/src/createApolloLoadingProvider.tsx
+++ b/src/createApolloLoadingProvider.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { ApolloLink, Observable } from 'apollo-link';
 import ApolloClient from 'apollo-client';
-import { ApolloProvider } from 'react-apollo';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloProviderProps, ApolloProvider } from 'react-apollo';
 
 export const createApolloLoadingProvider = (
-  globalCache?: ApolloCache<any>
+  globalCache?: ApolloCache<any>,
+  provider?: React.ComponentType<ApolloProviderProps<any>>
 ) => ({
   children,
   cache,
@@ -23,5 +24,6 @@ export const createApolloLoadingProvider = (
     cache: cache || globalCache || new InMemoryCache(),
   });
 
-  return <ApolloProvider client={client}>{children}</ApolloProvider>;
+  const Provider = provider ? provider : ApolloProvider;
+  return <Provider client={client}>{children}</Provider>;
 };

--- a/src/createApolloLoadingProvider.tsx
+++ b/src/createApolloLoadingProvider.tsx
@@ -3,12 +3,13 @@ import { ApolloLink, Observable } from 'apollo-link';
 import ApolloClient from 'apollo-client';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache } from 'apollo-cache-inmemory';
-import { ApolloProviderProps, ApolloProvider } from 'react-apollo';
+import { ApolloProvider } from 'react-apollo';
+import { ApolloMockedProviderOptions } from 'ApolloMockedProviderOptions';
 
-export const createApolloLoadingProvider = (
-  globalCache?: ApolloCache<any>,
-  provider?: React.ComponentType<ApolloProviderProps<any>>
-) => ({
+export const createApolloLoadingProvider = ({
+  cache: globalCache,
+  provider,
+}: ApolloMockedProviderOptions = {}) => ({
   children,
   cache,
 }: {

--- a/src/createApolloMockedProvider.tsx
+++ b/src/createApolloMockedProvider.tsx
@@ -8,12 +8,12 @@ import ApolloClient from 'apollo-client';
 import { SchemaLink } from 'apollo-link-schema';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache } from 'apollo-cache-inmemory';
-import { ApolloProviderProps, ApolloProvider } from 'react-apollo';
+import { ApolloProvider } from 'react-apollo';
+import { ApolloMockedProviderOptions } from 'ApolloMockedProviderOptions';
 
 export const createApolloMockedProvider = (
   typeDefs: ITypeDefinitions,
-  globalCache?: ApolloCache<any>,
-  provider?: React.ComponentType<ApolloProviderProps<any>>
+  { cache: globalCache, provider }: ApolloMockedProviderOptions = {}
 ) => ({
   customResolvers = {},
   cache,

--- a/src/createApolloMockedProvider.tsx
+++ b/src/createApolloMockedProvider.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ApolloProvider } from 'react-apollo';
 import {
   makeExecutableSchema,
   addMockFunctionsToSchema,
@@ -9,10 +8,12 @@ import ApolloClient from 'apollo-client';
 import { SchemaLink } from 'apollo-link-schema';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloProviderProps, ApolloProvider } from 'react-apollo';
 
 export const createApolloMockedProvider = (
   typeDefs: ITypeDefinitions,
-  globalCache?: ApolloCache<any>
+  globalCache?: ApolloCache<any>,
+  provider?: React.ComponentType<ApolloProviderProps<any>>
 ) => ({
   customResolvers = {},
   cache,
@@ -36,5 +37,6 @@ export const createApolloMockedProvider = (
     cache: cache || globalCache || new InMemoryCache(),
   });
 
-  return <ApolloProvider client={client}>{children}</ApolloProvider>;
+  const Provider = provider ? provider : ApolloProvider;
+  return <Provider client={client}>{children}</Provider>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './createApolloErrorProvider';
 export * from './createApolloLoadingProvider';
 export * from './createApolloMockedProvider';
+export * from './ApolloMockedProviderOptions';
 export * from './fetchTypeDefs';

--- a/test/createApolloErrorProvider.test.tsx
+++ b/test/createApolloErrorProvider.test.tsx
@@ -14,3 +14,13 @@ test('works with defaults', async () => {
   await waitForDomChange();
   expect(getByText('Error!')).toBeTruthy();
 });
+
+test('allows user to provide a custom provider', () => {
+  const MyCustomProvider = jest.fn(() => <div />);
+
+  const CustomizedProvider = createApolloErrorProvider({
+    provider: MyCustomProvider,
+  });
+  render(<CustomizedProvider graphQLErrors={[]}> </CustomizedProvider>);
+  expect(MyCustomProvider).toHaveBeenCalled();
+});

--- a/test/createApolloLoadingProvider.test.tsx
+++ b/test/createApolloLoadingProvider.test.tsx
@@ -13,3 +13,13 @@ test('works with defaults', async () => {
 
   expect(getByText('Loading...')).toBeTruthy();
 });
+
+test('allows user to provide a custom provider', () => {
+  const MyCustomProvider = jest.fn(() => <div />);
+
+  const CustomizedProvider = createApolloLoadingProvider({
+    provider: MyCustomProvider,
+  });
+  render(<CustomizedProvider> </CustomizedProvider>);
+  expect(MyCustomProvider).toHaveBeenCalled();
+});

--- a/test/createApolloMockedProvider.test.tsx
+++ b/test/createApolloMockedProvider.test.tsx
@@ -188,4 +188,14 @@ describe('caching', () => {
     expect(getByText('First Local Todo')).toBeTruthy();
     expect(getByText('Second Local Todo')).toBeTruthy();
   });
+
+  test('allows user to provide a custom provider', () => {
+    const MyCustomProvider = jest.fn(() => <div />);
+
+    const CustomizedProvider = createApolloMockedProvider(typeDefs, {
+      provider: MyCustomProvider,
+    });
+    render(<CustomizedProvider> </CustomizedProvider>);
+    expect(MyCustomProvider).toHaveBeenCalled();
+  });
 });

--- a/test/createApolloMockedProvider.test.tsx
+++ b/test/createApolloMockedProvider.test.tsx
@@ -55,7 +55,7 @@ test('works with custom resolvers', async () => {
 describe('caching', () => {
   test('allows users to provide a global cache', async () => {
     const cache = new InMemoryCache();
-    const FirstMockedProvider = createApolloMockedProvider(typeDefs, cache);
+    const FirstMockedProvider = createApolloMockedProvider(typeDefs, { cache });
     cache.writeQuery({
       query: GET_TODOS_QUERY,
       data: {
@@ -89,7 +89,9 @@ describe('caching', () => {
     expect(getByText('First Global Todo')).toBeTruthy();
     expect(getByText('Second Global Todo')).toBeTruthy();
 
-    const SecondMockedProvider = createApolloMockedProvider(typeDefs, cache);
+    const SecondMockedProvider = createApolloMockedProvider(typeDefs, {
+      cache,
+    });
     const { getByText: secondGetByText } = render(
       <SecondMockedProvider>
         <Todo />


### PR DESCRIPTION
This is useful if you are using react-apollo-hooks.