### PR TITLE
Fix issue with .d.ts files

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,26 @@ test('TodoForm', async () => {
 });
 ```
 
+Custom mocks mixed with errors (if you need to have some resolver succeed and then some others throw errors):
+
+```jsx
+<MockedProvider
+  customResolvers={{
+    Query: () => ({
+      todo: (_obj: any, args: any) => {
+        console.log(args.id)
+        throw new Error('Boom');
+      },
+      todos: () => [
+        {
+          text: 'Success',
+        },
+      ],
+    }),
+  }}
+>
+```
+
 ### Cache
 
 By default, providers will use a new instance of [`InMemoryCache`](https://www.apollographql.com/docs/react/advanced/caching/#inmemorycache), but you can override that at a global or per component level by providing an object that implements `ApolloCache` to the `create*` methods or mocked components respectively.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-mocked-provider",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Automatically mock GraphQL data with a mocked ApolloProvider",
   "author": "Ben Awad",
   "license": "MIT",

--- a/src/createApolloLoadingProvider.tsx
+++ b/src/createApolloLoadingProvider.tsx
@@ -4,7 +4,7 @@ import ApolloClient from 'apollo-client';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloProvider } from 'react-apollo';
-import { ApolloMockedProviderOptions } from 'ApolloMockedProviderOptions';
+import { ApolloMockedProviderOptions } from './ApolloMockedProviderOptions';
 
 export const createApolloLoadingProvider = ({
   cache: globalCache,

--- a/src/createApolloMockedProvider.tsx
+++ b/src/createApolloMockedProvider.tsx
@@ -11,7 +11,7 @@ import { onError } from 'apollo-link-error';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloProvider } from 'react-apollo';
-import { ApolloMockedProviderOptions } from 'ApolloMockedProviderOptions';
+import { ApolloMockedProviderOptions } from './ApolloMockedProviderOptions';
 
 export const createApolloMockedProvider = (
   typeDefs: ITypeDefinitions,


### PR DESCRIPTION
The import path for the new `ApolloMockedProviderOptions` was not properly
prefixed with `./` which caused issues when using the package in a
typescript project.

Also, added the example in the README because last time I forgot to
`git add` it.

And last but not least, bumped version number. Hope that is ok.