### PR TITLE
add: Ability to provide custom links to mocked provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,18 @@ export const ApolloLoadingProvider = createApolloLoadingProvider({
   provider: ApolloProvider,
 });
 ```
+
+### Using links
+
+If you would like to provide custom links in the chain of the mocked provider, you can pass them in the creation function.
+
+```jsx
+export const ApolloMockedProvider = createApolloMockedProvider(typeDefs, {
+  links: ({ cache, schema }) => [
+    myLinkFromCache(cache),
+    myLinkFromSchema(schema),
+  ],
+});
+```
+
+Custom links will be inserted before the terminating link which provides schema mocking.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-mocked-provider",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Automatically mock GraphQL data with a mocked ApolloProvider",
   "author": "Ben Awad",
   "license": "MIT",
@@ -70,8 +70,9 @@
     "typescript": "^3.5.2"
   },
   "dependencies": {
-    "apollo-cache-inmemory": "^1.6.2",
-    "apollo-client": "^2.6.2",
+    "apollo-cache-inmemory": "^1.6.3",
+    "apollo-client": "^2.6.4",
+    "apollo-link": "^1.2.13",
     "apollo-link-http": "^1.5.14",
     "apollo-link-schema": "^1.2.2",
     "graphql": "^14.3.1",

--- a/src/ApolloMockedProviderOptions.ts
+++ b/src/ApolloMockedProviderOptions.ts
@@ -1,7 +1,15 @@
 import { ApolloCache } from 'apollo-cache';
 import { ApolloProviderProps } from 'react-apollo';
+import { ApolloLink } from 'apollo-link';
+import { GraphQLSchema } from 'graphql';
+
+export interface LinksArgs {
+  cache: ApolloCache<any>;
+  schema: GraphQLSchema;
+}
 
 export interface ApolloMockedProviderOptions {
   cache?: ApolloCache<any>;
   provider?: React.ComponentType<ApolloProviderProps<any>>;
+  links?: (args: LinksArgs) => Array<ApolloLink>;
 }

--- a/src/createApolloMockedProvider.tsx
+++ b/src/createApolloMockedProvider.tsx
@@ -15,10 +15,10 @@ import { ApolloMockedProviderOptions } from './ApolloMockedProviderOptions';
 
 export const createApolloMockedProvider = (
   typeDefs: ITypeDefinitions,
-  { cache: globalCache, provider }: ApolloMockedProviderOptions = {}
+  { cache: globalCache, provider, links }: ApolloMockedProviderOptions = {}
 ) => ({
   customResolvers = {},
-  cache,
+  cache: componentCache,
   children,
 }: {
   customResolvers?: any;
@@ -34,9 +34,17 @@ export const createApolloMockedProvider = (
 
   addMockFunctionsToSchema({ schema, mocks: customResolvers });
 
+  const cache = componentCache || globalCache || new InMemoryCache();
+
+  const customLinks = links ? links({ cache, schema }) : [];
+
   const client = new ApolloClient({
-    link: ApolloLink.from([onError(() => {}), new SchemaLink({ schema })]),
-    cache: cache || globalCache || new InMemoryCache(),
+    link: ApolloLink.from([
+      onError(() => {}),
+      ...customLinks,
+      new SchemaLink({ schema }),
+    ]),
+    cache,
     defaultOptions: {
       mutate: { errorPolicy: 'all' },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,6 +1253,17 @@ apollo-cache-inmemory@^1.6.2:
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
+apollo-cache-inmemory@^1.6.3:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz#56d1f2a463a6b9db32e9fa990af16d2a008206fd"
+  integrity sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==
+  dependencies:
+    apollo-cache "^1.3.5"
+    apollo-utilities "^1.3.4"
+    optimism "^0.10.0"
+    ts-invariant "^0.4.0"
+    tslib "^1.10.0"
+
 apollo-cache@1.3.2, apollo-cache@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.2.tgz#df4dce56240d6c95c613510d7e409f7214e6d26a"
@@ -1261,19 +1272,13 @@ apollo-cache@1.3.2, apollo-cache@^1.3.2:
     apollo-utilities "^1.3.2"
     tslib "^1.9.3"
 
-apollo-client@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.2.tgz#03b6af651e09b6e413e486ddc87464c85bd6e514"
-  integrity sha512-oks1MaT5x7gHcPeC8vPC1UzzsKaEIC0tye+jg72eMDt5OKc7BobStTeS/o2Ib3e0ii40nKxGBnMdl/Xa/p56Yg==
+apollo-cache@1.3.5, apollo-cache@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.5.tgz#9dbebfc8dbe8fe7f97ba568a224bca2c5d81f461"
+  integrity sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==
   dependencies:
-    "@types/zen-observable" "^0.8.0"
-    apollo-cache "1.3.2"
-    apollo-link "^1.0.0"
-    apollo-utilities "1.3.2"
-    symbol-observable "^1.0.2"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-    zen-observable "^0.8.0"
+    apollo-utilities "^1.3.4"
+    tslib "^1.10.0"
 
 apollo-client@^2.6.3:
   version "2.6.3"
@@ -1287,6 +1292,20 @@ apollo-client@^2.6.3:
     symbol-observable "^1.0.2"
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
+    zen-observable "^0.8.0"
+
+apollo-client@^2.6.4:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.10.tgz#86637047b51d940c8eaa771a4ce1b02df16bea6a"
+  integrity sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==
+  dependencies:
+    "@types/zen-observable" "^0.8.0"
+    apollo-cache "1.3.5"
+    apollo-link "^1.0.0"
+    apollo-utilities "1.3.4"
+    symbol-observable "^1.0.2"
+    ts-invariant "^0.4.0"
+    tslib "^1.10.0"
     zen-observable "^0.8.0"
 
 apollo-link-error@^1.0.3:
@@ -1362,6 +1381,16 @@ apollo-link@^1.0.6, apollo-link@^1.2.12:
     tslib "^1.9.3"
     zen-observable-ts "^0.8.19"
 
+apollo-link@^1.2.13:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
+  integrity sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==
+  dependencies:
+    apollo-utilities "^1.3.0"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+    zen-observable-ts "^0.8.21"
+
 apollo-utilities@1.3.2, apollo-utilities@^1.0.1, apollo-utilities@^1.2.1, apollo-utilities@^1.3.0, apollo-utilities@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.2.tgz#8cbdcf8b012f664cd6cb5767f6130f5aed9115c9"
@@ -1371,6 +1400,16 @@ apollo-utilities@1.3.2, apollo-utilities@^1.0.1, apollo-utilities@^1.2.1, apollo
     fast-json-stable-stringify "^2.0.0"
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
+
+apollo-utilities@1.3.4, apollo-utilities@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.4.tgz#6129e438e8be201b6c55b0f13ce49d2c7175c9cf"
+  integrity sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==
+  dependencies:
+    "@wry/equality" "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
+    ts-invariant "^0.4.0"
+    tslib "^1.10.0"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -4612,6 +4651,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+optimism@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.10.3.tgz#163268fdc741dea2fb50f300bedda80356445fd7"
+  integrity sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==
+  dependencies:
+    "@wry/context" "^0.4.0"
+
 optimism@^0.9.0:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.9.5.tgz#b8b5dc9150e97b79ddbf2d2c6c0e44de4d255527"
@@ -6639,6 +6685,14 @@ zen-observable-ts@^0.8.19:
   version "0.8.19"
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz#c094cd20e83ddb02a11144a6e2a89706946b5694"
   integrity sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==
+  dependencies:
+    tslib "^1.9.3"
+    zen-observable "^0.8.0"
+
+zen-observable-ts@^0.8.21:
+  version "0.8.21"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz#85d0031fbbde1eba3cd07d3ba90da241215f421d"
+  integrity sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==
   dependencies:
     tslib "^1.9.3"
     zen-observable "^0.8.0"


### PR DESCRIPTION
This PR will:
- Add the ability to provide custom links to the mocked provider

Reasoning:
- Specifically, we have a link in our real apollo instance that handles cache updates, thus updating the UI.  Without being able to supply this link in the mocked provider, we cannot test UI updates resulting from this link's behavior.   I'm sure there are many valid use cases for passing custom links.

Points of interest:
- Does this API give enough flexibility for creating any link desired?
- Is it okay that the custom links are put between the error and schema links?

New deps:
- `apollo-link` was already a member of the node_modules due to another dependency, so I don't think it adds any overhead.