### PR TITLE
Feat/support client resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,13 @@ export const ApolloMockedProvider = createApolloMockedProvider(typeDefs, {
 ```
 
 Custom links will be inserted before the terminating link which provides schema mocking.
+
+### Using client resolvers
+
+If you are using client resolvers to manage local state, you can pass them in the creation function.
+
+```jsx
+export const ApolloMockedProvider = createApolloMockedProvider(typeDefs, {
+  clientResolvers,
+});
+```

--- a/src/ApolloMockedProviderOptions.ts
+++ b/src/ApolloMockedProviderOptions.ts
@@ -1,7 +1,7 @@
 import { ApolloCache } from 'apollo-cache';
 import { ApolloProviderProps } from 'react-apollo';
 import { ApolloLink } from 'apollo-link';
-import { GraphQLSchema } from 'graphql';
+import { GraphQLSchema, Resolvers } from 'graphql';
 
 export interface LinksArgs {
   cache: ApolloCache<any>;
@@ -12,4 +12,5 @@ export interface ApolloMockedProviderOptions {
   cache?: ApolloCache<any>;
   provider?: React.ComponentType<ApolloProviderProps<any>>;
   links?: (args: LinksArgs) => Array<ApolloLink>;
+  clientResolvers?: Resolvers | Resolvers[] | undefined;
 }

--- a/src/createApolloMockedProvider.tsx
+++ b/src/createApolloMockedProvider.tsx
@@ -15,7 +15,12 @@ import { ApolloMockedProviderOptions } from './ApolloMockedProviderOptions';
 
 export const createApolloMockedProvider = (
   typeDefs: ITypeDefinitions,
-  { cache: globalCache, provider, links }: ApolloMockedProviderOptions = {}
+  {
+    cache: globalCache,
+    provider,
+    links,
+    clientResolvers,
+  }: ApolloMockedProviderOptions = {}
 ) => ({
   customResolvers = {},
   cache: componentCache,
@@ -48,6 +53,7 @@ export const createApolloMockedProvider = (
     defaultOptions: {
       mutate: { errorPolicy: 'all' },
     },
+    resolvers: clientResolvers,
   });
 
   const Provider = provider ? provider : ApolloProvider;

--- a/test/createApolloMockedProvider.test.tsx
+++ b/test/createApolloMockedProvider.test.tsx
@@ -10,6 +10,7 @@ import {
 import {
   GET_TODO_QUERY,
   GET_TODOS_QUERY,
+  GET_TODOS_WITH_CLIENT_RESOLVER_QUERY,
   GetTodo,
   GetTodos,
   Todo,
@@ -94,6 +95,42 @@ test('works with custom links', async () => {
     expect.objectContaining({ addTypename: true }), // assert that the cache is passed
     expect.objectContaining({ astNode: undefined }) // assert that the schema is passed
   );
+});
+
+test('works with client resolvers', async () => {
+  const clientResolvers = {
+    Todo: {
+      text: () => 'client',
+    },
+  };
+
+  const MockedProvider = createApolloMockedProvider(typeDefs, {
+    clientResolvers,
+  });
+
+  const { getAllByText } = render(
+    <MockedProvider>
+      <Query<GetTodos> query={GET_TODOS_WITH_CLIENT_RESOLVER_QUERY}>
+        {({ loading, error, data }) => {
+          if (loading) return <p>Loading...</p>;
+          if (error) return <p>Error!</p>;
+          return (
+            <>
+              <ul data-testid="todolist">
+                {data!.todos.map((todo, idx) => (
+                  <li key={idx}>{todo.text}</li>
+                ))}
+              </ul>
+            </>
+          );
+        }}
+      </Query>
+    </MockedProvider>
+  );
+
+  await waitForDomChange();
+
+  expect(getAllByText('client')).toHaveLength(2);
 });
 
 test('allows throwing errors within resolvers to mock Query API errors', async () => {

--- a/test/fixtures/Todo.tsx
+++ b/test/fixtures/Todo.tsx
@@ -12,6 +12,16 @@ export const GET_TODOS_QUERY = gql`
   }
 `;
 
+export const GET_TODOS_WITH_CLIENT_RESOLVER_QUERY = gql`
+  query getTodosWithClientResolver {
+    todos {
+      id
+      text @client
+      createdTs
+    }
+  }
+`;
+
 export const GET_TODO_QUERY = gql`
   query getTodo($id: ID!) {
     todo(id: $id) {


### PR DESCRIPTION
Closes #21 

## Description

This PR:

- Adds the ability to pass client resolvers to the mocked provider