### PR TITLE
fix: import of graphql-tools to work with webpack

### DIFF
--- a/src/createApolloMockedProvider.tsx
+++ b/src/createApolloMockedProvider.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
-import { makeExecutableSchema, ITypeDefinitions } from 'graphql-tools';
 import { addMocksToSchema } from '@graphql-tools/mock';
+import { makeExecutableSchema } from '@graphql-tools/schema';
 import { ApolloMockedProviderOptions } from './ApolloMockedProviderOptions';
 import {
   ApolloCache,
@@ -11,6 +11,7 @@ import {
 } from '@apollo/client';
 import { SchemaLink } from '@apollo/client/link/schema';
 import { onError } from '@apollo/client/link/error';
+import { ITypeDefinitions } from '@graphql-tools/utils';
 
 export const createApolloMockedProvider = (
   typeDefs: ITypeDefinitions,


### PR DESCRIPTION
I made a last minute mistake when I was cleaning up yesterday.

It's very important to **not** import `graphql-tools` because it references the package `resolve-from` which confuses webpack and causes an error. (We also get a ton of warnings because other parts of `graphql-tools` use conditionals require which webpack also does not like).

It's possible to make webpack ignore it but it's going to be easier for everyone if we just avoid the problem by importing the sub-pieces of graphql-tools we do need (and the sub-pieces do not refer the problematic packages).

I think with this commit message and the semantic-release gh action we should get a 4.0.1 automatically so I have not updated the version number.

For reference this is the error I get in my project when I use `apollo-mocked-provider` 4.0.0 as it is now:

```
ERROR in ../node_modules/resolve-from/index.js
Module not found: Error: Can't resolve 'module' in '/Users/thomas/work/chartedsails/node_modules/resolve-from'
 @ ../node_modules/resolve-from/index.js 3:15-32
 @ ../node_modules/@graphql-tools/import/index.esm.js
 @ ../node_modules/apollo-mocked-provider/node_modules/graphql-tools/index.esm.js
 @ ../node_modules/apollo-mocked-provider/dist/apollo-mocked-provider.es.production.js
 @ ./src/backend/__mocks__/gqlmocks.tsx
```
