### PR TITLE
feature: Add option to specify global mocks

### DIFF
--- a/src/ApolloMockedProviderOptions.ts
+++ b/src/ApolloMockedProviderOptions.ts
@@ -10,4 +10,5 @@ export interface ApolloMockedProviderOptions {
   cache?: ApolloCache<any>;
   links?: (args: LinksArgs) => Array<ApolloLink>;
   defaultOptions?: DefaultOptions;
+  globalResolvers?: any;
 }

--- a/src/createApolloMockedProvider.tsx
+++ b/src/createApolloMockedProvider.tsx
@@ -12,6 +12,7 @@ import {
 import { SchemaLink } from '@apollo/client/link/schema';
 import { onError } from '@apollo/client/link/error';
 import { ITypeDefinitions } from '@graphql-tools/utils';
+import { mergeResolvers } from '@graphql-tools/merge';
 
 export const createApolloMockedProvider = (
   typeDefs: ITypeDefinitions,
@@ -19,6 +20,7 @@ export const createApolloMockedProvider = (
     cache: globalCache,
     links,
     defaultOptions,
+    globalResolvers,
   }: ApolloMockedProviderOptions = {}
 ) => ({
   customResolvers = {},
@@ -29,7 +31,7 @@ export const createApolloMockedProvider = (
   children: ReactNode;
   cache?: ApolloCache<any>;
 }) => {
-  // const mocks = mergeResolvers(globalMocks, props.customResolvers);
+  const mocks = mergeResolvers([globalResolvers, customResolvers]);
 
   const baseSchema = makeExecutableSchema({
     typeDefs,
@@ -38,7 +40,7 @@ export const createApolloMockedProvider = (
 
   const schema = addMocksToSchema({
     schema: baseSchema,
-    mocks: customResolvers,
+    mocks,
   });
 
   const cache = componentCache || globalCache || new InMemoryCache();

--- a/test/createApolloMockedProvider.test.tsx
+++ b/test/createApolloMockedProvider.test.tsx
@@ -25,6 +25,77 @@ test('works with defaults', async () => {
   expect(todoList.children.length).toBeGreaterThanOrEqual(1);
 });
 
+test('works with global resolvers', async () => {
+  const globalResolvers = {
+    Query: () => ({
+      todos: () => [
+        {
+          text: 'First Todo',
+        },
+        {
+          text: 'Second Todo',
+        },
+      ],
+    }),
+  };
+
+  const MockedProvider = createApolloMockedProvider(typeDefs, {
+    globalResolvers,
+  });
+  const { getByText } = render(
+    <MockedProvider>
+      <TodoApp />
+    </MockedProvider>
+  );
+
+  await waitFor(() => {});
+  expect(getByText('First Todo')).toBeTruthy();
+  expect(getByText('Second Todo')).toBeTruthy();
+});
+
+test('custom resolvers override global resolvers that conflict', async () => {
+  const globalResolvers = {
+    Query: () => ({
+      todos: () => [
+        {
+          text: 'First Todo',
+        },
+        {
+          text: 'Second Todo',
+        },
+      ],
+    }),
+  };
+
+  const MockedProvider = createApolloMockedProvider(typeDefs, {
+    globalResolvers,
+  });
+  const { getByText, queryByText } = render(
+    <MockedProvider
+      customResolvers={{
+        Query: () => ({
+          todos: () => [
+            {
+              text: 'Custom First Todo',
+            },
+            {
+              text: 'Custom Second Todo',
+            },
+          ],
+        }),
+      }}
+    >
+      <TodoApp />
+    </MockedProvider>
+  );
+
+  await waitFor(() => {});
+  expect(getByText('Custom First Todo')).toBeTruthy();
+  expect(getByText('Custom Second Todo')).toBeTruthy();
+  expect(queryByText('First Todo')).not.toBeTruthy();
+  expect(queryByText('Second Todo')).not.toBeTruthy();
+});
+
 test('works with custom resolvers', async () => {
   const MockedProvider = createApolloMockedProvider(typeDefs);
   const { getByText } = render(


### PR DESCRIPTION
Closes #10 
### What does this PR do?
Allows for the specification of global resolvers that can be used throughout all tests.
Makes use of the [mergeResolvers](https://www.graphql-tools.com/docs/schema-merging/#merging-resolvers) function provided by GraphQL Tools.
